### PR TITLE
Adding H5P.Text 1.0 in options in semantics.json

### DIFF
--- a/semantics.json
+++ b/semantics.json
@@ -62,7 +62,8 @@
                       "H5P.Table 1.1",
                       "H5P.InteractiveVideo 1.10",
                       "H5P.TwitterUserFeed 1.0",
-                      "H5P.AppearIn 1.0"
+                      "H5P.AppearIn 1.0",
+                      "H5P.Text 1.0"
                     ],
                     "optional": true
                   },


### PR DESCRIPTION
Adding H5P.Text 1.0 in options in semantics.json  because it is causing  error "Library used in content is not a valid library according to semantics."  during update to newer version.
