### PR TITLE
Quick fix for Facebook quote encoding

### DIFF
--- a/library.json
+++ b/library.json
@@ -3,7 +3,7 @@
   "contentType": "Library",
   "majorVersion": 1,
   "minorVersion": 17,
-  "patchVersion": 3,
+  "patchVersion": 4,
   "runnable": 1,
   "fullscreen": 1,
   "embedTypes": [

--- a/scripts/summary-slide.js
+++ b/scripts/summary-slide.js
@@ -325,6 +325,7 @@ H5P.CoursePresentation.SummarySlide = (function ($, JoubelUI) {
 
     // Parse data from the localization object.
     facebookShareUrl = encodeURIComponent(facebookShareUrl);
+    facebookShareQuote = encodeURIComponent(facebookShareQuote);
 
     // Add query strings to the URL based on settings.
     var facebookUrl = 'https://www.facebook.com/sharer/sharer.php?';


### PR DESCRIPTION
The encoding for the Facebook share quote was missed which leads to obvious disaster when using ampersand or question mark characters in it. Just a one-liner to correct that.