### PR TITLE
Add scoring with pass grade and overall feedback

### DIFF
--- a/language/.en.json
+++ b/language/.en.json
@@ -283,6 +283,43 @@
       ]
     },
     {
+      "label": "Scoring",
+      "description": "These options will let you set score related settings.",
+      "fields": [
+        {
+          "label": "Pass percentage",
+          "description": "Percentage of total score required for passing the course presentation."
+        },
+        {
+          "label": "Overall Feedback",
+          "fields": [
+            {
+              "widgets": [
+                {
+                  "label": "Default"
+                }
+              ],
+              "label": "Define custom feedback for any score range",
+              "description": "Click the \"Add range\" button to add as many ranges as you need. Example: 0-20% Bad score, 21-91% Average Score, 91-100% Great Score!",
+              "entity": "range",
+              "field": {
+                "fields": [
+                  {
+                    "label": "Score Range"
+                  },
+                  {},
+                  {
+                    "label": "Feedback for defined score range",
+                    "placeholder": "Fill in the feedback"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "label": "Behaviour settings.",
       "description": "These options will let you override behaviour settings.",
       "fields": [

--- a/language/af.json
+++ b/language/af.json
@@ -283,6 +283,43 @@
       ]
     },
     {
+      "label": "Scoring",
+      "description": "These options will let you set score related settings.",
+      "fields": [
+        {
+          "label": "Pass percentage",
+          "description": "Percentage of total score required for passing the course presentation."
+        },
+        {
+          "label": "Overall Feedback",
+          "fields": [
+            {
+              "widgets": [
+                {
+                  "label": "Default"
+                }
+              ],
+              "label": "Define custom feedback for any score range",
+              "description": "Click the \"Add range\" button to add as many ranges as you need. Example: 0-20% Bad score, 21-91% Average Score, 91-100% Great Score!",
+              "entity": "range",
+              "field": {
+                "fields": [
+                  {
+                    "label": "Score Range"
+                  },
+                  {},
+                  {
+                    "label": "Feedback for defined score range",
+                    "placeholder": "Fill in the feedback"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "label": "Gedragsinstellings.",
       "description": "Hierdie opsies sal jou in staat stel om gedragsinstellings te oorskry.",
       "fields": [

--- a/language/ar.json
+++ b/language/ar.json
@@ -283,6 +283,43 @@
       ]
     },
     {
+      "label": "Scoring",
+      "description": "These options will let you set score related settings.",
+      "fields": [
+        {
+          "label": "Pass percentage",
+          "description": "Percentage of total score required for passing the course presentation."
+        },
+        {
+          "label": "Overall Feedback",
+          "fields": [
+            {
+              "widgets": [
+                {
+                  "label": "Default"
+                }
+              ],
+              "label": "Define custom feedback for any score range",
+              "description": "Click the \"Add range\" button to add as many ranges as you need. Example: 0-20% Bad score, 21-91% Average Score, 91-100% Great Score!",
+              "entity": "range",
+              "field": {
+                "fields": [
+                  {
+                    "label": "Score Range"
+                  },
+                  {},
+                  {
+                    "label": "Feedback for defined score range",
+                    "placeholder": "Fill in the feedback"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "label": "إعدادات السلوك.",
       "description": "تتيح لك هذه الخيارات تجاوز إعدادات السلوك.",
       "fields": [

--- a/language/bg.json
+++ b/language/bg.json
@@ -283,6 +283,43 @@
       ]
     },
     {
+      "label": "Scoring",
+      "description": "These options will let you set score related settings.",
+      "fields": [
+        {
+          "label": "Pass percentage",
+          "description": "Percentage of total score required for passing the course presentation."
+        },
+        {
+          "label": "Overall Feedback",
+          "fields": [
+            {
+              "widgets": [
+                {
+                  "label": "Default"
+                }
+              ],
+              "label": "Define custom feedback for any score range",
+              "description": "Click the \"Add range\" button to add as many ranges as you need. Example: 0-20% Bad score, 21-91% Average Score, 91-100% Great Score!",
+              "entity": "range",
+              "field": {
+                "fields": [
+                  {
+                    "label": "Score Range"
+                  },
+                  {},
+                  {
+                    "label": "Feedback for defined score range",
+                    "placeholder": "Fill in the feedback"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "label": "Настройки за поведението.",
       "description": "Тези опции ще ви позволят да промените настройките за поведение.",
       "fields": [

--- a/language/bs.json
+++ b/language/bs.json
@@ -283,6 +283,43 @@
       ]
     },
     {
+      "label": "Scoring",
+      "description": "These options will let you set score related settings.",
+      "fields": [
+        {
+          "label": "Pass percentage",
+          "description": "Percentage of total score required for passing the course presentation."
+        },
+        {
+          "label": "Overall Feedback",
+          "fields": [
+            {
+              "widgets": [
+                {
+                  "label": "Default"
+                }
+              ],
+              "label": "Define custom feedback for any score range",
+              "description": "Click the \"Add range\" button to add as many ranges as you need. Example: 0-20% Bad score, 21-91% Average Score, 91-100% Great Score!",
+              "entity": "range",
+              "field": {
+                "fields": [
+                  {
+                    "label": "Score Range"
+                  },
+                  {},
+                  {
+                    "label": "Feedback for defined score range",
+                    "placeholder": "Fill in the feedback"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "label": "Podešavanje ponašanja.",
       "description": "Ova opcija će vam omogućiti da preskočite podešavanja ponašanja.",
       "fields": [

--- a/language/ca.json
+++ b/language/ca.json
@@ -283,6 +283,43 @@
       ]
     },
     {
+      "label": "Scoring",
+      "description": "These options will let you set score related settings.",
+      "fields": [
+        {
+          "label": "Pass percentage",
+          "description": "Percentage of total score required for passing the course presentation."
+        },
+        {
+          "label": "Overall Feedback",
+          "fields": [
+            {
+              "widgets": [
+                {
+                  "label": "Default"
+                }
+              ],
+              "label": "Define custom feedback for any score range",
+              "description": "Click the \"Add range\" button to add as many ranges as you need. Example: 0-20% Bad score, 21-91% Average Score, 91-100% Great Score!",
+              "entity": "range",
+              "field": {
+                "fields": [
+                  {
+                    "label": "Score Range"
+                  },
+                  {},
+                  {
+                    "label": "Feedback for defined score range",
+                    "placeholder": "Fill in the feedback"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "label": "Configuració de  la retroacció.",
       "description": "Aquestes opcions us permeten modificar el comportament dels suggeriments.",
       "fields": [

--- a/language/cs.json
+++ b/language/cs.json
@@ -283,6 +283,43 @@
       ]
     },
     {
+      "label": "Scoring",
+      "description": "These options will let you set score related settings.",
+      "fields": [
+        {
+          "label": "Pass percentage",
+          "description": "Percentage of total score required for passing the course presentation."
+        },
+        {
+          "label": "Overall Feedback",
+          "fields": [
+            {
+              "widgets": [
+                {
+                  "label": "Default"
+                }
+              ],
+              "label": "Define custom feedback for any score range",
+              "description": "Click the \"Add range\" button to add as many ranges as you need. Example: 0-20% Bad score, 21-91% Average Score, 91-100% Great Score!",
+              "entity": "range",
+              "field": {
+                "fields": [
+                  {
+                    "label": "Score Range"
+                  },
+                  {},
+                  {
+                    "label": "Feedback for defined score range",
+                    "placeholder": "Fill in the feedback"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "label": "Nastavení chování.",
       "description": "Tyto možnosti vám umožní přepsat nastavení chování.",
       "fields": [

--- a/language/da.json
+++ b/language/da.json
@@ -283,6 +283,43 @@
       ]
     },
     {
+      "label": "Scoring",
+      "description": "These options will let you set score related settings.",
+      "fields": [
+        {
+          "label": "Pass percentage",
+          "description": "Percentage of total score required for passing the course presentation."
+        },
+        {
+          "label": "Overall Feedback",
+          "fields": [
+            {
+              "widgets": [
+                {
+                  "label": "Default"
+                }
+              ],
+              "label": "Define custom feedback for any score range",
+              "description": "Click the \"Add range\" button to add as many ranges as you need. Example: 0-20% Bad score, 21-91% Average Score, 91-100% Great Score!",
+              "entity": "range",
+              "field": {
+                "fields": [
+                  {
+                    "label": "Score Range"
+                  },
+                  {},
+                  {
+                    "label": "Feedback for defined score range",
+                    "placeholder": "Fill in the feedback"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "label": "Indstillinger for handling.",
       "description": "Disse muligheder vil overskrive indstillinger for handling.",
       "fields": [

--- a/language/de.json
+++ b/language/de.json
@@ -283,6 +283,43 @@
       ]
     },
     {
+      "label": "Scoring",
+      "description": "These options will let you set score related settings.",
+      "fields": [
+        {
+          "label": "Pass percentage",
+          "description": "Percentage of total score required for passing the course presentation."
+        },
+        {
+          "label": "Overall Feedback",
+          "fields": [
+            {
+              "widgets": [
+                {
+                  "label": "Default"
+                }
+              ],
+              "label": "Define custom feedback for any score range",
+              "description": "Click the \"Add range\" button to add as many ranges as you need. Example: 0-20% Bad score, 21-91% Average Score, 91-100% Great Score!",
+              "entity": "range",
+              "field": {
+                "fields": [
+                  {
+                    "label": "Score Range"
+                  },
+                  {},
+                  {
+                    "label": "Feedback for defined score range",
+                    "placeholder": "Fill in the feedback"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "label": "Verhaltenseinstellungen",
       "description": "Diese Optionen legen fest, wie die die Präsentation im Detail funktioniert.",
       "fields": [

--- a/language/el.json
+++ b/language/el.json
@@ -283,6 +283,43 @@
       ]
     },
     {
+      "label": "Scoring",
+      "description": "These options will let you set score related settings.",
+      "fields": [
+        {
+          "label": "Pass percentage",
+          "description": "Percentage of total score required for passing the course presentation."
+        },
+        {
+          "label": "Overall Feedback",
+          "fields": [
+            {
+              "widgets": [
+                {
+                  "label": "Default"
+                }
+              ],
+              "label": "Define custom feedback for any score range",
+              "description": "Click the \"Add range\" button to add as many ranges as you need. Example: 0-20% Bad score, 21-91% Average Score, 91-100% Great Score!",
+              "entity": "range",
+              "field": {
+                "fields": [
+                  {
+                    "label": "Score Range"
+                  },
+                  {},
+                  {
+                    "label": "Feedback for defined score range",
+                    "placeholder": "Fill in the feedback"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "label": "Ρυθμίσεις",
       "description": "Αυτές οι ρυθμίσεις σας επιτρέπουν να αντικαταστήσετε τις προκαθορισμένες ρυθμίσεις λειτουργίας.",
       "fields": [

--- a/language/es-mx.json
+++ b/language/es-mx.json
@@ -283,6 +283,43 @@
       ]
     },
     {
+      "label": "Scoring",
+      "description": "These options will let you set score related settings.",
+      "fields": [
+        {
+          "label": "Pass percentage",
+          "description": "Percentage of total score required for passing the course presentation."
+        },
+        {
+          "label": "Overall Feedback",
+          "fields": [
+            {
+              "widgets": [
+                {
+                  "label": "Default"
+                }
+              ],
+              "label": "Define custom feedback for any score range",
+              "description": "Click the \"Add range\" button to add as many ranges as you need. Example: 0-20% Bad score, 21-91% Average Score, 91-100% Great Score!",
+              "entity": "range",
+              "field": {
+                "fields": [
+                  {
+                    "label": "Score Range"
+                  },
+                  {},
+                  {
+                    "label": "Feedback for defined score range",
+                    "placeholder": "Fill in the feedback"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "label": "Opciones del comportamiento.",
       "description": "Estas opciones le permitirán anular los ajustes de comportamiento.",
       "fields": [

--- a/language/es.json
+++ b/language/es.json
@@ -283,6 +283,43 @@
       ]
     },
     {
+      "label": "Scoring",
+      "description": "These options will let you set score related settings.",
+      "fields": [
+        {
+          "label": "Pass percentage",
+          "description": "Percentage of total score required for passing the course presentation."
+        },
+        {
+          "label": "Overall Feedback",
+          "fields": [
+            {
+              "widgets": [
+                {
+                  "label": "Default"
+                }
+              ],
+              "label": "Define custom feedback for any score range",
+              "description": "Click the \"Add range\" button to add as many ranges as you need. Example: 0-20% Bad score, 21-91% Average Score, 91-100% Great Score!",
+              "entity": "range",
+              "field": {
+                "fields": [
+                  {
+                    "label": "Score Range"
+                  },
+                  {},
+                  {
+                    "label": "Feedback for defined score range",
+                    "placeholder": "Fill in the feedback"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "label": "Opciones del comportamiento.",
       "description": "Estas opciones le permitirán anular los ajustes de comportamiento.",
       "fields": [

--- a/language/et.json
+++ b/language/et.json
@@ -283,6 +283,43 @@
       ]
     },
     {
+      "label": "Scoring",
+      "description": "These options will let you set score related settings.",
+      "fields": [
+        {
+          "label": "Pass percentage",
+          "description": "Percentage of total score required for passing the course presentation."
+        },
+        {
+          "label": "Overall Feedback",
+          "fields": [
+            {
+              "widgets": [
+                {
+                  "label": "Default"
+                }
+              ],
+              "label": "Define custom feedback for any score range",
+              "description": "Click the \"Add range\" button to add as many ranges as you need. Example: 0-20% Bad score, 21-91% Average Score, 91-100% Great Score!",
+              "entity": "range",
+              "field": {
+                "fields": [
+                  {
+                    "label": "Score Range"
+                  },
+                  {},
+                  {
+                    "label": "Feedback for defined score range",
+                    "placeholder": "Fill in the feedback"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "label": "Käitumisseadistused.",
       "description": "Nende valikutega saad muuta vaikekäitumist.",
       "fields": [

--- a/language/eu.json
+++ b/language/eu.json
@@ -283,6 +283,43 @@
       ]
     },
     {
+      "label": "Scoring",
+      "description": "These options will let you set score related settings.",
+      "fields": [
+        {
+          "label": "Pass percentage",
+          "description": "Percentage of total score required for passing the course presentation."
+        },
+        {
+          "label": "Overall Feedback",
+          "fields": [
+            {
+              "widgets": [
+                {
+                  "label": "Default"
+                }
+              ],
+              "label": "Define custom feedback for any score range",
+              "description": "Click the \"Add range\" button to add as many ranges as you need. Example: 0-20% Bad score, 21-91% Average Score, 91-100% Great Score!",
+              "entity": "range",
+              "field": {
+                "fields": [
+                  {
+                    "label": "Score Range"
+                  },
+                  {},
+                  {
+                    "label": "Feedback for defined score range",
+                    "placeholder": "Fill in the feedback"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "label": "Portaera ezarpenak.",
       "description": "Aukera hauen bidez zuzendu ahal izango dituzu portaera ezarpenak.",
       "fields": [

--- a/language/fi.json
+++ b/language/fi.json
@@ -283,6 +283,43 @@
       ]
     },
     {
+      "label": "Scoring",
+      "description": "These options will let you set score related settings.",
+      "fields": [
+        {
+          "label": "Pass percentage",
+          "description": "Percentage of total score required for passing the course presentation."
+        },
+        {
+          "label": "Overall Feedback",
+          "fields": [
+            {
+              "widgets": [
+                {
+                  "label": "Default"
+                }
+              ],
+              "label": "Define custom feedback for any score range",
+              "description": "Click the \"Add range\" button to add as many ranges as you need. Example: 0-20% Bad score, 21-91% Average Score, 91-100% Great Score!",
+              "entity": "range",
+              "field": {
+                "fields": [
+                  {
+                    "label": "Score Range"
+                  },
+                  {},
+                  {
+                    "label": "Feedback for defined score range",
+                    "placeholder": "Fill in the feedback"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "label": "Asetukset",
       "description": "Nämä asetukset mahdollistavat oletusasetusten yliajamisen.",
       "fields": [

--- a/language/fr.json
+++ b/language/fr.json
@@ -283,6 +283,43 @@
       ]
     },
     {
+      "label": "Scoring",
+      "description": "These options will let you set score related settings.",
+      "fields": [
+        {
+          "label": "Pass percentage",
+          "description": "Percentage of total score required for passing the course presentation."
+        },
+        {
+          "label": "Overall Feedback",
+          "fields": [
+            {
+              "widgets": [
+                {
+                  "label": "Default"
+                }
+              ],
+              "label": "Define custom feedback for any score range",
+              "description": "Click the \"Add range\" button to add as many ranges as you need. Example: 0-20% Bad score, 21-91% Average Score, 91-100% Great Score!",
+              "entity": "range",
+              "field": {
+                "fields": [
+                  {
+                    "label": "Score Range"
+                  },
+                  {},
+                  {
+                    "label": "Feedback for defined score range",
+                    "placeholder": "Fill in the feedback"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "label": "Réglages généraux",
       "description": "Ces options vous permettent d'enlever certains réglages.",
       "fields": [

--- a/language/gl.json
+++ b/language/gl.json
@@ -283,6 +283,43 @@
       ]
     },
     {
+      "label": "Scoring",
+      "description": "These options will let you set score related settings.",
+      "fields": [
+        {
+          "label": "Pass percentage",
+          "description": "Percentage of total score required for passing the course presentation."
+        },
+        {
+          "label": "Overall Feedback",
+          "fields": [
+            {
+              "widgets": [
+                {
+                  "label": "Default"
+                }
+              ],
+              "label": "Define custom feedback for any score range",
+              "description": "Click the \"Add range\" button to add as many ranges as you need. Example: 0-20% Bad score, 21-91% Average Score, 91-100% Great Score!",
+              "entity": "range",
+              "field": {
+                "fields": [
+                  {
+                    "label": "Score Range"
+                  },
+                  {},
+                  {
+                    "label": "Feedback for defined score range",
+                    "placeholder": "Fill in the feedback"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "label": "Configuración de comportamento.",
       "description": "Estas opcións permiten anular a configuración do comportamento.",
       "fields": [

--- a/language/he.json
+++ b/language/he.json
@@ -283,6 +283,43 @@
       ]
     },
     {
+      "label": "Scoring",
+      "description": "These options will let you set score related settings.",
+      "fields": [
+        {
+          "label": "Pass percentage",
+          "description": "Percentage of total score required for passing the course presentation."
+        },
+        {
+          "label": "Overall Feedback",
+          "fields": [
+            {
+              "widgets": [
+                {
+                  "label": "Default"
+                }
+              ],
+              "label": "Define custom feedback for any score range",
+              "description": "Click the \"Add range\" button to add as many ranges as you need. Example: 0-20% Bad score, 21-91% Average Score, 91-100% Great Score!",
+              "entity": "range",
+              "field": {
+                "fields": [
+                  {
+                    "label": "Score Range"
+                  },
+                  {},
+                  {
+                    "label": "Feedback for defined score range",
+                    "placeholder": "Fill in the feedback"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "label": "הגדרות התנהגות.",
       "description": "הגדרות אלה יאפשרו לכם לעקוף את הגדרות ההתנהגות.",
       "fields": [

--- a/language/id.json
+++ b/language/id.json
@@ -71,7 +71,7 @@
                   {
                     "label": "Gambar",
                     "description": "Gambar latar harus memiliki rasio 2:1 untuk lebar terhadap tinggi untuk mencegah peregangan. Gambar dalam resolusi tinggi akan tampak lebih baik pada layar yang lebar."
-                   },
+                  },
                   {
                     "label": "Pilih warna",
                     "default": ""
@@ -279,6 +279,43 @@
         {
           "label": "Keluar dari pengumuman layar penuh untuk teknologi asistif",
           "default": "Keluar dari layar penuh"
+        }
+      ]
+    },
+    {
+      "label": "Scoring",
+      "description": "These options will let you set score related settings.",
+      "fields": [
+        {
+          "label": "Pass percentage",
+          "description": "Percentage of total score required for passing the course presentation."
+        },
+        {
+          "label": "Overall Feedback",
+          "fields": [
+            {
+              "widgets": [
+                {
+                  "label": "Default"
+                }
+              ],
+              "label": "Define custom feedback for any score range",
+              "description": "Click the \"Add range\" button to add as many ranges as you need. Example: 0-20% Bad score, 21-91% Average Score, 91-100% Great Score!",
+              "entity": "range",
+              "field": {
+                "fields": [
+                  {
+                    "label": "Score Range"
+                  },
+                  {},
+                  {
+                    "label": "Feedback for defined score range",
+                    "placeholder": "Fill in the feedback"
+                  }
+                ]
+              }
+            }
+          ]
         }
       ]
     },

--- a/language/it.json
+++ b/language/it.json
@@ -283,6 +283,43 @@
       ]
     },
     {
+      "label": "Scoring",
+      "description": "These options will let you set score related settings.",
+      "fields": [
+        {
+          "label": "Pass percentage",
+          "description": "Percentage of total score required for passing the course presentation."
+        },
+        {
+          "label": "Overall Feedback",
+          "fields": [
+            {
+              "widgets": [
+                {
+                  "label": "Default"
+                }
+              ],
+              "label": "Define custom feedback for any score range",
+              "description": "Click the \"Add range\" button to add as many ranges as you need. Example: 0-20% Bad score, 21-91% Average Score, 91-100% Great Score!",
+              "entity": "range",
+              "field": {
+                "fields": [
+                  {
+                    "label": "Score Range"
+                  },
+                  {},
+                  {
+                    "label": "Feedback for defined score range",
+                    "placeholder": "Fill in the feedback"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "label": "Impostazioni di esecuzione",
       "description": "Queste opzioni ti consentono di ignorare le impostazioni di esecuzione",
       "fields": [

--- a/language/ja.json
+++ b/language/ja.json
@@ -283,6 +283,43 @@
       ]
     },
     {
+      "label": "Scoring",
+      "description": "These options will let you set score related settings.",
+      "fields": [
+        {
+          "label": "Pass percentage",
+          "description": "Percentage of total score required for passing the course presentation."
+        },
+        {
+          "label": "Overall Feedback",
+          "fields": [
+            {
+              "widgets": [
+                {
+                  "label": "Default"
+                }
+              ],
+              "label": "Define custom feedback for any score range",
+              "description": "Click the \"Add range\" button to add as many ranges as you need. Example: 0-20% Bad score, 21-91% Average Score, 91-100% Great Score!",
+              "entity": "range",
+              "field": {
+                "fields": [
+                  {
+                    "label": "Score Range"
+                  },
+                  {},
+                  {
+                    "label": "Feedback for defined score range",
+                    "placeholder": "Fill in the feedback"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "label": "動作設定",
       "description": "これらのオプションは動作設定を上書きします。",
       "fields": [

--- a/language/km.json
+++ b/language/km.json
@@ -283,6 +283,43 @@
       ]
     },
     {
+      "label": "Scoring",
+      "description": "These options will let you set score related settings.",
+      "fields": [
+        {
+          "label": "Pass percentage",
+          "description": "Percentage of total score required for passing the course presentation."
+        },
+        {
+          "label": "Overall Feedback",
+          "fields": [
+            {
+              "widgets": [
+                {
+                  "label": "Default"
+                }
+              ],
+              "label": "Define custom feedback for any score range",
+              "description": "Click the \"Add range\" button to add as many ranges as you need. Example: 0-20% Bad score, 21-91% Average Score, 91-100% Great Score!",
+              "entity": "range",
+              "field": {
+                "fields": [
+                  {
+                    "label": "Score Range"
+                  },
+                  {},
+                  {
+                    "label": "Feedback for defined score range",
+                    "placeholder": "Fill in the feedback"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "label": "ការកំណត់មុខងារ",
       "description": "ជម្រើសទាំងនេះនឹងអនុញ្ញាតឲ្យអ្នកបង្ខំការកំណត់ផ្សេងៗ។",
       "fields": [

--- a/language/ko.json
+++ b/language/ko.json
@@ -283,6 +283,43 @@
       ]
     },
     {
+      "label": "Scoring",
+      "description": "These options will let you set score related settings.",
+      "fields": [
+        {
+          "label": "Pass percentage",
+          "description": "Percentage of total score required for passing the course presentation."
+        },
+        {
+          "label": "Overall Feedback",
+          "fields": [
+            {
+              "widgets": [
+                {
+                  "label": "Default"
+                }
+              ],
+              "label": "Define custom feedback for any score range",
+              "description": "Click the \"Add range\" button to add as many ranges as you need. Example: 0-20% Bad score, 21-91% Average Score, 91-100% Great Score!",
+              "entity": "range",
+              "field": {
+                "fields": [
+                  {
+                    "label": "Score Range"
+                  },
+                  {},
+                  {
+                    "label": "Feedback for defined score range",
+                    "placeholder": "Fill in the feedback"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "label": "동작 설정",
       "description": "이 옵션들은 동작 설정을 덮어쓰기 합니다",
       "fields": [

--- a/language/nb.json
+++ b/language/nb.json
@@ -283,6 +283,43 @@
       ]
     },
     {
+      "label": "Scoring",
+      "description": "These options will let you set score related settings.",
+      "fields": [
+        {
+          "label": "Pass percentage",
+          "description": "Percentage of total score required for passing the course presentation."
+        },
+        {
+          "label": "Overall Feedback",
+          "fields": [
+            {
+              "widgets": [
+                {
+                  "label": "Default"
+                }
+              ],
+              "label": "Define custom feedback for any score range",
+              "description": "Click the \"Add range\" button to add as many ranges as you need. Example: 0-20% Bad score, 21-91% Average Score, 91-100% Great Score!",
+              "entity": "range",
+              "field": {
+                "fields": [
+                  {
+                    "label": "Score Range"
+                  },
+                  {},
+                  {
+                    "label": "Feedback for defined score range",
+                    "placeholder": "Fill in the feedback"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "label": "Innstillinger for oppførsel.",
       "description": "Disse alternativene vil la deg overstyre innstillinger.",
       "fields": [

--- a/language/nl.json
+++ b/language/nl.json
@@ -283,6 +283,43 @@
       ]
     },
     {
+      "label": "Scoring",
+      "description": "These options will let you set score related settings.",
+      "fields": [
+        {
+          "label": "Pass percentage",
+          "description": "Percentage of total score required for passing the course presentation."
+        },
+        {
+          "label": "Overall Feedback",
+          "fields": [
+            {
+              "widgets": [
+                {
+                  "label": "Default"
+                }
+              ],
+              "label": "Define custom feedback for any score range",
+              "description": "Click the \"Add range\" button to add as many ranges as you need. Example: 0-20% Bad score, 21-91% Average Score, 91-100% Great Score!",
+              "entity": "range",
+              "field": {
+                "fields": [
+                  {
+                    "label": "Score Range"
+                  },
+                  {},
+                  {
+                    "label": "Feedback for defined score range",
+                    "placeholder": "Fill in the feedback"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "label": "Gedragsinstellingen",
       "description": "Met deze opties kun je de gedragsinstellingen overschrijven.",
       "fields": [

--- a/language/nn.json
+++ b/language/nn.json
@@ -283,6 +283,43 @@
       ]
     },
     {
+      "label": "Scoring",
+      "description": "These options will let you set score related settings.",
+      "fields": [
+        {
+          "label": "Pass percentage",
+          "description": "Percentage of total score required for passing the course presentation."
+        },
+        {
+          "label": "Overall Feedback",
+          "fields": [
+            {
+              "widgets": [
+                {
+                  "label": "Default"
+                }
+              ],
+              "label": "Define custom feedback for any score range",
+              "description": "Click the \"Add range\" button to add as many ranges as you need. Example: 0-20% Bad score, 21-91% Average Score, 91-100% Great Score!",
+              "entity": "range",
+              "field": {
+                "fields": [
+                  {
+                    "label": "Score Range"
+                  },
+                  {},
+                  {
+                    "label": "Feedback for defined score range",
+                    "placeholder": "Fill in the feedback"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "label": "Innstillinger for oppførsel.",
       "description": "Disse alternativene vil la deg overstyre innstillinger.",
       "fields": [

--- a/language/pl.json
+++ b/language/pl.json
@@ -283,6 +283,43 @@
       ]
     },
     {
+      "label": "Scoring",
+      "description": "These options will let you set score related settings.",
+      "fields": [
+        {
+          "label": "Pass percentage",
+          "description": "Percentage of total score required for passing the course presentation."
+        },
+        {
+          "label": "Overall Feedback",
+          "fields": [
+            {
+              "widgets": [
+                {
+                  "label": "Default"
+                }
+              ],
+              "label": "Define custom feedback for any score range",
+              "description": "Click the \"Add range\" button to add as many ranges as you need. Example: 0-20% Bad score, 21-91% Average Score, 91-100% Great Score!",
+              "entity": "range",
+              "field": {
+                "fields": [
+                  {
+                    "label": "Score Range"
+                  },
+                  {},
+                  {
+                    "label": "Feedback for defined score range",
+                    "placeholder": "Fill in the feedback"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "label": "Ustawienia zachowania.",
       "description": "Te opcje nadpiszą domyślne udstawienia zachowania.",
       "fields": [

--- a/language/pt-br.json
+++ b/language/pt-br.json
@@ -283,6 +283,43 @@
       ]
     },
     {
+      "label": "Scoring",
+      "description": "These options will let you set score related settings.",
+      "fields": [
+        {
+          "label": "Pass percentage",
+          "description": "Percentage of total score required for passing the course presentation."
+        },
+        {
+          "label": "Overall Feedback",
+          "fields": [
+            {
+              "widgets": [
+                {
+                  "label": "Default"
+                }
+              ],
+              "label": "Define custom feedback for any score range",
+              "description": "Click the \"Add range\" button to add as many ranges as you need. Example: 0-20% Bad score, 21-91% Average Score, 91-100% Great Score!",
+              "entity": "range",
+              "field": {
+                "fields": [
+                  {
+                    "label": "Score Range"
+                  },
+                  {},
+                  {
+                    "label": "Feedback for defined score range",
+                    "placeholder": "Fill in the feedback"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "label": "Configurações comportamentais.",
       "description": "Estas opções permitirão que você controle como a tarefa se comporta.",
       "fields": [

--- a/language/pt.json
+++ b/language/pt.json
@@ -283,6 +283,43 @@
       ]
     },
     {
+      "label": "Scoring",
+      "description": "These options will let you set score related settings.",
+      "fields": [
+        {
+          "label": "Pass percentage",
+          "description": "Percentage of total score required for passing the course presentation."
+        },
+        {
+          "label": "Overall Feedback",
+          "fields": [
+            {
+              "widgets": [
+                {
+                  "label": "Default"
+                }
+              ],
+              "label": "Define custom feedback for any score range",
+              "description": "Click the \"Add range\" button to add as many ranges as you need. Example: 0-20% Bad score, 21-91% Average Score, 91-100% Great Score!",
+              "entity": "range",
+              "field": {
+                "fields": [
+                  {
+                    "label": "Score Range"
+                  },
+                  {},
+                  {
+                    "label": "Feedback for defined score range",
+                    "placeholder": "Fill in the feedback"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "label": "Definições de funcionamento",
       "description": "Estas opções vão sobrepor as definições de funcionamento por defeito.",
       "fields": [

--- a/language/ru.json
+++ b/language/ru.json
@@ -283,6 +283,43 @@
       ]
     },
     {
+      "label": "Scoring",
+      "description": "These options will let you set score related settings.",
+      "fields": [
+        {
+          "label": "Pass percentage",
+          "description": "Percentage of total score required for passing the course presentation."
+        },
+        {
+          "label": "Overall Feedback",
+          "fields": [
+            {
+              "widgets": [
+                {
+                  "label": "Default"
+                }
+              ],
+              "label": "Define custom feedback for any score range",
+              "description": "Click the \"Add range\" button to add as many ranges as you need. Example: 0-20% Bad score, 21-91% Average Score, 91-100% Great Score!",
+              "entity": "range",
+              "field": {
+                "fields": [
+                  {
+                    "label": "Score Range"
+                  },
+                  {},
+                  {
+                    "label": "Feedback for defined score range",
+                    "placeholder": "Fill in the feedback"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "label": "Настройки поведения.",
       "description": "Эти параметры позволят вам переопределить настройки поведения.",
       "fields": [

--- a/language/sl.json
+++ b/language/sl.json
@@ -283,6 +283,43 @@
       ]
     },
     {
+      "label": "Scoring",
+      "description": "These options will let you set score related settings.",
+      "fields": [
+        {
+          "label": "Pass percentage",
+          "description": "Percentage of total score required for passing the course presentation."
+        },
+        {
+          "label": "Overall Feedback",
+          "fields": [
+            {
+              "widgets": [
+                {
+                  "label": "Default"
+                }
+              ],
+              "label": "Define custom feedback for any score range",
+              "description": "Click the \"Add range\" button to add as many ranges as you need. Example: 0-20% Bad score, 21-91% Average Score, 91-100% Great Score!",
+              "entity": "range",
+              "field": {
+                "fields": [
+                  {
+                    "label": "Score Range"
+                  },
+                  {},
+                  {
+                    "label": "Feedback for defined score range",
+                    "placeholder": "Fill in the feedback"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "label": "Nastavitve interakcije",
       "description": "Nastavitve omogočajo nadzor nad interakcijo aktivnosti za udeležence.",
       "fields": [

--- a/language/sma.json
+++ b/language/sma.json
@@ -283,6 +283,43 @@
       ]
     },
     {
+      "label": "Scoring",
+      "description": "These options will let you set score related settings.",
+      "fields": [
+        {
+          "label": "Pass percentage",
+          "description": "Percentage of total score required for passing the course presentation."
+        },
+        {
+          "label": "Overall Feedback",
+          "fields": [
+            {
+              "widgets": [
+                {
+                  "label": "Default"
+                }
+              ],
+              "label": "Define custom feedback for any score range",
+              "description": "Click the \"Add range\" button to add as many ranges as you need. Example: 0-20% Bad score, 21-91% Average Score, 91-100% Great Score!",
+              "entity": "range",
+              "field": {
+                "fields": [
+                  {
+                    "label": "Score Range"
+                  },
+                  {},
+                  {
+                    "label": "Feedback for defined score range",
+                    "placeholder": "Fill in the feedback"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "label": "Behaviour settings.",
       "description": "These options will let you override behaviour settings.",
       "fields": [

--- a/language/sme.json
+++ b/language/sme.json
@@ -283,6 +283,43 @@
       ]
     },
     {
+      "label": "Scoring",
+      "description": "These options will let you set score related settings.",
+      "fields": [
+        {
+          "label": "Pass percentage",
+          "description": "Percentage of total score required for passing the course presentation."
+        },
+        {
+          "label": "Overall Feedback",
+          "fields": [
+            {
+              "widgets": [
+                {
+                  "label": "Default"
+                }
+              ],
+              "label": "Define custom feedback for any score range",
+              "description": "Click the \"Add range\" button to add as many ranges as you need. Example: 0-20% Bad score, 21-91% Average Score, 91-100% Great Score!",
+              "entity": "range",
+              "field": {
+                "fields": [
+                  {
+                    "label": "Score Range"
+                  },
+                  {},
+                  {
+                    "label": "Feedback for defined score range",
+                    "placeholder": "Fill in the feedback"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "label": "Behaviour settings.",
       "description": "These options will let you override behaviour settings.",
       "fields": [

--- a/language/smj.json
+++ b/language/smj.json
@@ -283,6 +283,43 @@
       ]
     },
     {
+      "label": "Scoring",
+      "description": "These options will let you set score related settings.",
+      "fields": [
+        {
+          "label": "Pass percentage",
+          "description": "Percentage of total score required for passing the course presentation."
+        },
+        {
+          "label": "Overall Feedback",
+          "fields": [
+            {
+              "widgets": [
+                {
+                  "label": "Default"
+                }
+              ],
+              "label": "Define custom feedback for any score range",
+              "description": "Click the \"Add range\" button to add as many ranges as you need. Example: 0-20% Bad score, 21-91% Average Score, 91-100% Great Score!",
+              "entity": "range",
+              "field": {
+                "fields": [
+                  {
+                    "label": "Score Range"
+                  },
+                  {},
+                  {
+                    "label": "Feedback for defined score range",
+                    "placeholder": "Fill in the feedback"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "label": "Behaviour settings.",
       "description": "These options will let you override behaviour settings.",
       "fields": [

--- a/language/sv.json
+++ b/language/sv.json
@@ -283,6 +283,43 @@
       ]
     },
     {
+      "label": "Scoring",
+      "description": "These options will let you set score related settings.",
+      "fields": [
+        {
+          "label": "Pass percentage",
+          "description": "Percentage of total score required for passing the course presentation."
+        },
+        {
+          "label": "Overall Feedback",
+          "fields": [
+            {
+              "widgets": [
+                {
+                  "label": "Default"
+                }
+              ],
+              "label": "Define custom feedback for any score range",
+              "description": "Click the \"Add range\" button to add as many ranges as you need. Example: 0-20% Bad score, 21-91% Average Score, 91-100% Great Score!",
+              "entity": "range",
+              "field": {
+                "fields": [
+                  {
+                    "label": "Score Range"
+                  },
+                  {},
+                  {
+                    "label": "Feedback for defined score range",
+                    "placeholder": "Fill in the feedback"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "label": "Beteende-inställningar.",
       "description": "Dessa inställningar gör det möjligt att ignorera beteende-inställningar.",
       "fields": [

--- a/language/tr.json
+++ b/language/tr.json
@@ -283,6 +283,43 @@
       ]
     },
     {
+      "label": "Scoring",
+      "description": "These options will let you set score related settings.",
+      "fields": [
+        {
+          "label": "Pass percentage",
+          "description": "Percentage of total score required for passing the course presentation."
+        },
+        {
+          "label": "Overall Feedback",
+          "fields": [
+            {
+              "widgets": [
+                {
+                  "label": "Default"
+                }
+              ],
+              "label": "Define custom feedback for any score range",
+              "description": "Click the \"Add range\" button to add as many ranges as you need. Example: 0-20% Bad score, 21-91% Average Score, 91-100% Great Score!",
+              "entity": "range",
+              "field": {
+                "fields": [
+                  {
+                    "label": "Score Range"
+                  },
+                  {},
+                  {
+                    "label": "Feedback for defined score range",
+                    "placeholder": "Fill in the feedback"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "label": "Davranış ayarları.",
       "description": "Bu seçenekler davranış ayarlarını geçersiz kılmanızı sağlar.",
       "fields": [

--- a/language/uk.json
+++ b/language/uk.json
@@ -283,6 +283,43 @@
       ]
     },
     {
+      "label": "Scoring",
+      "description": "These options will let you set score related settings.",
+      "fields": [
+        {
+          "label": "Pass percentage",
+          "description": "Percentage of total score required for passing the course presentation."
+        },
+        {
+          "label": "Overall Feedback",
+          "fields": [
+            {
+              "widgets": [
+                {
+                  "label": "Default"
+                }
+              ],
+              "label": "Define custom feedback for any score range",
+              "description": "Click the \"Add range\" button to add as many ranges as you need. Example: 0-20% Bad score, 21-91% Average Score, 91-100% Great Score!",
+              "entity": "range",
+              "field": {
+                "fields": [
+                  {
+                    "label": "Score Range"
+                  },
+                  {},
+                  {
+                    "label": "Feedback for defined score range",
+                    "placeholder": "Fill in the feedback"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "label": "Настройки поведінки.",
       "description": "Ці параметри дозволять Вам переназначити настройки поведінки.",
       "fields": [

--- a/language/zh-hans.json
+++ b/language/zh-hans.json
@@ -283,6 +283,43 @@
       ]
     },
     {
+      "label": "Scoring",
+      "description": "These options will let you set score related settings.",
+      "fields": [
+        {
+          "label": "Pass percentage",
+          "description": "Percentage of total score required for passing the course presentation."
+        },
+        {
+          "label": "Overall Feedback",
+          "fields": [
+            {
+              "widgets": [
+                {
+                  "label": "Default"
+                }
+              ],
+              "label": "Define custom feedback for any score range",
+              "description": "Click the \"Add range\" button to add as many ranges as you need. Example: 0-20% Bad score, 21-91% Average Score, 91-100% Great Score!",
+              "entity": "range",
+              "field": {
+                "fields": [
+                  {
+                    "label": "Score Range"
+                  },
+                  {},
+                  {
+                    "label": "Feedback for defined score range",
+                    "placeholder": "Fill in the feedback"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "label": "行为设定",
       "description": "这些设定会覆盖默认值。",
       "fields": [

--- a/language/zh-tw.json
+++ b/language/zh-tw.json
@@ -283,6 +283,43 @@
       ]
     },
     {
+      "label": "Scoring",
+      "description": "These options will let you set score related settings.",
+      "fields": [
+        {
+          "label": "Pass percentage",
+          "description": "Percentage of total score required for passing the course presentation."
+        },
+        {
+          "label": "Overall Feedback",
+          "fields": [
+            {
+              "widgets": [
+                {
+                  "label": "Default"
+                }
+              ],
+              "label": "Define custom feedback for any score range",
+              "description": "Click the \"Add range\" button to add as many ranges as you need. Example: 0-20% Bad score, 21-91% Average Score, 91-100% Great Score!",
+              "entity": "range",
+              "field": {
+                "fields": [
+                  {
+                    "label": "Score Range"
+                  },
+                  {},
+                  {
+                    "label": "Feedback for defined score range",
+                    "placeholder": "Fill in the feedback"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "label": "行為設定.",
       "description": "這些選項將讓您覆蓋行為設定.",
       "fields": [

--- a/language/zh.json
+++ b/language/zh.json
@@ -283,6 +283,43 @@
       ]
     },
     {
+      "label": "Scoring",
+      "description": "These options will let you set score related settings.",
+      "fields": [
+        {
+          "label": "Pass percentage",
+          "description": "Percentage of total score required for passing the course presentation."
+        },
+        {
+          "label": "Overall Feedback",
+          "fields": [
+            {
+              "widgets": [
+                {
+                  "label": "Default"
+                }
+              ],
+              "label": "Define custom feedback for any score range",
+              "description": "Click the \"Add range\" button to add as many ranges as you need. Example: 0-20% Bad score, 21-91% Average Score, 91-100% Great Score!",
+              "entity": "range",
+              "field": {
+                "fields": [
+                  {
+                    "label": "Score Range"
+                  },
+                  {},
+                  {
+                    "label": "Feedback for defined score range",
+                    "placeholder": "Fill in the feedback"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "label": "行為設定",
       "description": "這些設定會覆蓋預設值。",
       "fields": [

--- a/library.json
+++ b/library.json
@@ -2,8 +2,8 @@
   "title": "Course Presentation",
   "contentType": "Library",
   "majorVersion": 1,
-  "minorVersion": 22,
-  "patchVersion": 5,
+  "minorVersion": 23,
+  "patchVersion": 0,
   "runnable": 1,
   "fullscreen": 1,
   "embedTypes": [
@@ -52,7 +52,7 @@
     {
       "machineName": "H5PEditor.CoursePresentation",
       "majorVersion": 1,
-      "minorVersion": 22
+      "minorVersion": 23
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "h5p-course-presentation",
-  "version": "1.20.0",
+  "version": "1.23.0",
   "description": "A free HTML5- based presentation content type which allows users to add multiple choice, fill in the blanks, texts and other types of interactions to their presentations using only a web browser.",
   "private": true,
   "scripts": {

--- a/semantics.json
+++ b/semantics.json
@@ -652,6 +652,85 @@
     ]
   },
   {
+    "name": "scoring",
+    "type": "group",
+    "label": "Scoring",
+    "importance": "low",
+    "description": "These options will let you set score related settings.",
+    "optional": true,
+    "fields": [
+      {
+        "name": "passPercentage",
+        "type": "number",
+        "label": "Pass percentage",
+        "importance": "low",
+        "description": "Percentage of total score required for passing the course presentation.",
+        "min": 0,
+        "max": 100,
+        "step": 1,
+        "default": 100
+      },
+      {
+        "name": "overallFeedback",
+        "type": "group",
+        "label": "Overall Feedback",
+        "importance": "low",
+        "expanded": true,
+        "fields": [
+          {
+            "name": "overallFeedback",
+            "type": "list",
+            "widgets": [
+              {
+                "name": "RangeList",
+                "label": "Default"
+              }
+            ],
+            "importance": "high",
+            "label": "Define custom feedback for any score range",
+            "description": "Click the \"Add range\" button to add as many ranges as you need. Example: 0-20% Bad score, 21-91% Average Score, 91-100% Great Score!",
+            "entity": "range",
+            "min": 1,
+            "defaultNum": 1,
+            "optional": true,
+            "field": {
+              "name": "overallFeedback",
+              "type": "group",
+              "importance": "low",
+              "fields": [
+                {
+                  "name": "from",
+                  "type": "number",
+                  "label": "Score Range",
+                  "min": 0,
+                  "max": 100,
+                  "default": 0,
+                  "unit": "%"
+                },
+                {
+                  "name": "to",
+                  "type": "number",
+                  "min": 0,
+                  "max": 100,
+                  "default": 100,
+                  "unit": "%"
+                },
+                {
+                  "name": "feedback",
+                  "type": "text",
+                  "label": "Feedback for defined score range",
+                  "importance": "low",
+                  "placeholder": "Fill in the feedback",
+                  "optional": true
+                }
+              ]
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
     "name": "override",
     "type": "group",
     "label": "Behaviour settings.",

--- a/src/scripts/cp.js
+++ b/src/scripts/cp.js
@@ -23,6 +23,20 @@ const KEYWORD_TITLE_SKIP = null;
  */
 let CoursePresentation = function (params, id, extras) {
   var that = this;
+
+  // Sanitize params
+  this.params = $.extend({
+    scoring: {
+      passPercentage: 100,
+      overallFeedback: []
+    }
+  }, params);
+
+  // Sanitize overall feedback
+  if (this.params.scoring.overallFeedback.length === 0) {
+    this.params.scoring.overallFeedback.push({from: 0, to: 100});
+  }
+
   this.presentation = params.presentation;
   this.slides = this.presentation.slides;
   this.contentId = id;
@@ -2130,7 +2144,8 @@ CoursePresentation.prototype.getXAPIData = function () {
 
   var score = this.getScore();
   var maxScore = this.getMaxScore();
-  xAPIEvent.setScoredResult(score, maxScore, this, true, score === maxScore);
+  const success = score * 100 / maxScore >= this.params.scoring.passPercentage;
+  xAPIEvent.setScoredResult(score, maxScore, this, true, success);
 
   var childrenXAPIData = flattenArray(this.slidesWithSolutions).map((child) => {
     if (child && child.getXAPIData) {

--- a/src/scripts/summary-slide.js
+++ b/src/scripts/summary-slide.js
@@ -91,6 +91,20 @@ const SummarySlide = (function () {
           event.preventDefault();
         });
       });
+
+      // Update overall feedback
+      const scoreText = H5P.Question.determineOverallFeedback(that.cp.params.scoring.overallFeedback, totalScores.totalScore / totalScores.totalMaxScore)
+        .replace('@score', totalScores.totalScore)
+        .replace('@total', totalScores.totalMaxScore)
+        .trim();
+
+      if (scoreText !== '') {
+        $('.h5p-summary-overall-feedback').removeClass('hidden');
+        $('.h5p-summary-overall-feedback-text', that.$summarySlide).html(scoreText);
+      }
+      else {
+        $('.h5p-summary-overall-feedback').addClass('hidden');
+      }
     }
 
     // Button container ref
@@ -188,7 +202,8 @@ const SummarySlide = (function () {
       totalMaxScore += slideScores[i].maxScore;
     }
 
-    that.cp.triggerXAPICompleted(totalScore, totalMaxScore);
+    const success = totalScore * 100 / totalMaxScore >= that.cp.params.scoring.passPercentage;
+    that.cp.triggerXAPICompleted(totalScore, totalMaxScore, success);
     var shareResultContainer = (that.cp.enableTwitterShare || that.cp.enableFacebookShare || that.cp.enableGoogleShare) ? '<span class="h5p-show-results-text">' + that.cp.l10n.shareResult + '</span>' : '';
     var twitterContainer = (that.cp.enableTwitterShare == true) ? '<span class="h5p-summary-twitter-message" aria-label="' + that.cp.l10n.shareTwitter + '"></span>': '';
     var facebookContainer = (that.cp.enableFacebookShare == true) ? '<span class="h5p-summary-facebook-message" aria-label="' + that.cp.l10n.shareFacebook + '"></span>': '';
@@ -216,6 +231,9 @@ const SummarySlide = (function () {
             '<p>' + that.cp.l10n.totalScore + '</p>' +
           '</div>' +
         '</div>' +
+        '<div class="h5p-summary-overall-feedback">' +
+          '<div class="h5p-summary-overall-feedback-text"></div>' +
+        '</div>' +        
       '</div>' +
       '<div class="h5p-summary-footer">' +
       '</div>';

--- a/src/styles/summary-slide.css
+++ b/src/styles/summary-slide.css
@@ -180,6 +180,19 @@
   padding: 0 0.1em;
 }
 
+.h5p-course-presentation .h5p-summary-overall-feedback {
+  margin-top: 4em;
+}
+
+.h5p-course-presentation .h5p-summary-overall-feedback.hidden {
+  display: none;
+}
+
+.h5p-course-presentation .h5p-summary-overall-feedback .h5p-summary-overall-feedback-text {
+  color: #1a73d9;
+  font-weight: bold;
+}
+
 /* ---------------------------- Social media styles ---------------------------------------------- */
 
 /* Facebook and Twitter link styling */

--- a/upgrades.js
+++ b/upgrades.js
@@ -1,6 +1,6 @@
 var H5PUpgrades = H5PUpgrades || {};
 
-H5PUpgrades['H5P.CoursePresentation'] = (function () {
+H5PUpgrades['H5P.CoursePresentationWorkseed'] = (function () {
   return {
     1: {
       2: function (parameters, finished) {
@@ -329,6 +329,27 @@ H5PUpgrades['H5P.CoursePresentation'] = (function () {
               }
             });
           }
+        }
+
+        // Done
+        finished(null, parameters);
+      },
+
+      /**
+       * Asynchronous content upgrade hook.
+       * Upgrades content parameters to support CP 1.23.
+       *
+       * Set scoring
+       *
+       * @param {Object} parameters
+       * @param {function} finished
+       */
+      23: function (parameters, finished) {
+        if (parameters) {
+          parameters.scoring = {
+            passPercentage: 100,
+            overallFeedback: [{from: 0, to: 100}]
+          };
         }
 
         // Done


### PR DESCRIPTION
There was a [request on the H5P forum](https://h5p.org/node/1154886) to merge some features of Question Set into Course Presentation:
- As an author, I can set a passing percentage that needs to be achieved in order to register a successful attempt.
- As an author, I can set overall feedback that will be given to the user based on the score that was achieved.

When merged in, those user stories will be implemented by:
- Add a scoring option group to set both, the pass percentage and the overall feedback. The default for the pass percentage is 100 to not interfere with how existing content behaves. The overall feedback is the usual option set.
- Display the overall feedback on the summary slide
- Amend the xAPI `result` property of the `answered` statement with the success flag based on the pass percentage.