### PR TITLE
HFP-2030 Fix - slide menu opacity

### DIFF
--- a/src/scripts/cp.js
+++ b/src/scripts/cp.js
@@ -673,7 +673,7 @@ CoursePresentation.prototype.showKeywords = function () {
  * @param {number} value 0 - 100
  */
 CoursePresentation.prototype.setKeywordsOpacity = function (value) {
-  const [red, green, blue] = this.$keywordsWrapper.css('background-color').split(/\(|\)|,/g);
+  const [red, green, blue] = this.$keywordsWrapper.css('background-color').match(/\d+/g);
   this.$keywordsWrapper.css('background-color', `rgba(${red}, ${green}, ${blue}, ${value / 100})`);
 };
 


### PR DESCRIPTION
Opacity in keywords menu didn't work due to the regular expression retrieving values `RGB`, `#`, `#` and `#` from the CSS style. Replaced with another regular expression that only retrieves the numeric values.