### PR TITLE
HFP-2394 Fix IV bug when popup is closed and reopened

### DIFF
--- a/src/scripts/cp.js
+++ b/src/scripts/cp.js
@@ -1254,7 +1254,7 @@ CoursePresentation.prototype.addElementSolutionButton = function (element, eleme
  * @param {object} [instance] H5P library instance
  * @param {boolean} [keepInDOM] Hide the popup instead of removing it when it gets closed
  */
-CoursePresentation.prototype.showPopup = function (popupContent, $focusOnClose, parentPosition = null, remove, classes = 'h5p-popup-comment-field', instance, keepInDOM = true) {
+CoursePresentation.prototype.showPopup = function (popupContent, $focusOnClose, parentPosition = null, remove, classes = 'h5p-popup-comment-field', instance, keepInDOM = false) {
   var self = this;
   var doNotClose;
 


### PR DESCRIPTION
This commit adds logic to allow popups to remain in the DOM, but hidden,
instead of always being detached/removed which was the old behavior.

As of now, this will be the case for any interaction popups containing
an Interactive Video, regardless of the video source.