### PR TITLE
HFP-3825 Do not send xAPI completed on resume

### DIFF
--- a/src/scripts/cp.js
+++ b/src/scripts/cp.js
@@ -443,7 +443,7 @@ CoursePresentation.prototype.attach = function ($container) {
   new SlideBackground(this);
 
   if (this.previousState && this.previousState.progress) {
-    this.jumpToSlide(this.previousState.progress, false, null, false, true);
+    this.jumpToSlide(this.previousState.progress, false, null, false, true, true);
   }
 };
 
@@ -1843,9 +1843,11 @@ CoursePresentation.prototype.attachAllElements = function () {
  *
  * @param {number} slideNumber The slide number to jump to.
  * @param {Boolean} [noScroll] Skip UI scrolling.
+ * @param {Boolean} [handleFocus] If true, will focus the slide number announcer.
+ * @param {Boolean} [noXAPI] If true, will not trigger xAPI events.
  * @returns {Boolean} Always true.
  */
-CoursePresentation.prototype.processJumpToSlide = function (slideNumber, noScroll, handleFocus) {
+CoursePresentation.prototype.processJumpToSlide = function (slideNumber, noScroll, handleFocus, noXAPI) {
   var that = this;
   if (this.editor === undefined && this.contentId) { // Content ID avoids crash when previewing in editor before saving
     var progressedEvent = this.createXAPIEventTemplate('progressed');
@@ -1940,7 +1942,7 @@ CoursePresentation.prototype.processJumpToSlide = function (slideNumber, noScrol
 
   if (that.summarySlideObject) {
     // Update summary slide if on last slide, do not jump
-    that.summarySlideObject.updateSummarySlide(slideNumber, true);
+    that.summarySlideObject.updateSummarySlide(slideNumber, true, noXAPI);
   }
 
   // Editor specific settings
@@ -1962,9 +1964,17 @@ CoursePresentation.prototype.processJumpToSlide = function (slideNumber, noScrol
  * @param {Boolean} [noScroll] Skip UI scrolling.
  * @param {Function|null} [callback] Callback to execute on successfull navigation
  * @param {Boolean} [ignoreConfirmationDialog] Will not show confirmation dialog for summary slide
+ * @param {Boolean} [noXAPI] If true, will not trigger xAPI events.
  * @returns {Boolean}
  */
-CoursePresentation.prototype.jumpToSlide = function (slideNumber, noScroll = false, callback = null, handleFocus = false, ignoreConfirmationDialog = false) {
+CoursePresentation.prototype.jumpToSlide = function (
+  slideNumber,
+  noScroll = false,
+  callback = null,
+  handleFocus = false,
+  ignoreConfirmationDialog = false,
+  noXAPI = false
+) {
   if (this.standalone
     && this.showSummarySlide
     && slideNumber === this.slides.length - 1
@@ -1988,14 +1998,14 @@ CoursePresentation.prototype.jumpToSlide = function (slideNumber, noScroll = fal
       return false;
     });
     confirmationDialog.on('confirmed', () => {
-      this.processJumpToSlide(slideNumber, noScroll, handleFocus);
+      this.processJumpToSlide(slideNumber, noScroll, handleFocus, noXAPI);
       if (callback) {
         callback();
       }
     });
   }
   else {
-    this.processJumpToSlide(slideNumber, noScroll, handleFocus);
+    this.processJumpToSlide(slideNumber, noScroll, handleFocus, noXAPI);
     if (callback) {
       callback();
     }

--- a/src/scripts/summary-slide.js
+++ b/src/scripts/summary-slide.js
@@ -19,8 +19,9 @@ const SummarySlide = (function () {
    * Updates the provided summary slide with current values.
    *
    * @param {$} $summarySlide Summary slide that will be updated
+   * @param {Boolean} [noXAPI] If true, will not trigger xAPI events.
    */
-  SummarySlide.prototype.updateSummarySlide = function (slideNumber, noJump) {
+  SummarySlide.prototype.updateSummarySlide = function (slideNumber, noJump, noXAPI) {
     var that = this;
     // Validate update.
     var isValidUpdate = (this.cp.editor === undefined) && (this.$summarySlide !== undefined) && (slideNumber >= this.cp.slides.length - 1);
@@ -39,7 +40,7 @@ const SummarySlide = (function () {
 
     // Get scores and updated html for summary slide
     var slideScores = that.cp.getSlideScores(noJump);
-    var htmlText = that.outputScoreStats(slideScores);
+    var htmlText = that.outputScoreStats(slideScores, noXAPI);
     $(htmlText).appendTo(that.$summarySlide);
 
     if (!isExportSlide) {
@@ -146,9 +147,10 @@ const SummarySlide = (function () {
    * Gets html for summary slide.
    *
    * @param slideScores Scores for all pages
+   * @param {Boolean} [noXAPI] If true, will not trigger xAPI events.
    * @returns {string} html
    */
-  SummarySlide.prototype.outputScoreStats = function (slideScores) {
+  SummarySlide.prototype.outputScoreStats = function (slideScores, noXAPI) {
     var self = this;
     if (slideScores === undefined) {
       this.$summarySlide.addClass('h5p-summary-only-export');
@@ -189,7 +191,7 @@ const SummarySlide = (function () {
     }
 
     // this.cp.ignoreResize is true when printing; do not xAPI submit on print.
-    if (!this.cp.isSolutionMode && !this.cp.ignoreResize) {
+    if (!this.cp.isSolutionMode && !this.cp.ignoreResize && !noXAPI) {
       that.cp.triggerXAPICompleted(totalScore, totalMaxScore);
     }
     var shareResultContainer = (that.cp.enableTwitterShare || that.cp.enableFacebookShare || that.cp.enableGoogleShare) ? '<span class="h5p-show-results-text">' + that.cp.l10n.shareResult + '</span>' : '';


### PR DESCRIPTION
When merged in, will not trigger an xAPI completed statement if the Course Presentation is resumed and the user stopped on the summary slide.

Course Presentation triggers an xAPI `completed` statement whenever the user opens the summary slide. When he/she closed the Course Presentation and later resumed, Course Presentation would recreate the previous state including the summary slide being opened and sending out an xAPI `completed` statement again. That feels wrong though and might mess with learning record stores or gradebooks which might register this as a new attempt.