### PR TITLE
VA-897 Remove text decoration (underline) from navigation parts

### DIFF
--- a/src/styles/navigation-line.css
+++ b/src/styles/navigation-line.css
@@ -270,20 +270,20 @@
 
 /* The summary slide icon */
 .h5p-course-presentation .h5p-progressbar .h5p-progressbar-part.progressbar-part-summary-slide a:after {
-
   font-family: "h5p-theme";
   content: "\e90a";
   font-size: 0.5em;
   margin: 0 auto;
   text-align: center;
-  text-decoration: none;
   color: var(--h5p-theme-secondary-cta-base);
 }
 .h5p-course-presentation .h5p-progressbar .h5p-progressbar-part-selected.progressbar-part-summary-slide a:after{
   color: var(--h5p-theme-contrast-cta);
 }
 
-
+.h5p-course-presentation .h5p-progressbar .h5p-progressbar-part.progressbar-part-summary-slide a {
+  text-decoration: none;
+}
 
 .h5p-course-presentation .h5p-progressbar .h5p-progressbar-part {
   flex: 1;


### PR DESCRIPTION
When merged in, will remove the text decoration (underline) from navigation parts, the summary page icon in particular.