### PR TITLE
VA-922 Fix SCS not listed as task in nav bar

### DIFF
--- a/src/scripts/element.js
+++ b/src/scripts/element.js
@@ -1,4 +1,5 @@
 import GoToSlide from './go-to-slide';
+import { isTask } from  './utils.js';
 
 /**
  * @class
@@ -56,7 +57,9 @@ function Element(parameters) {
     self.parent.parent.elementInstances[self.parent.index].push(self.instance);
   }
 
-  if (self.instance.showCPComments !== undefined || self.instance.isTask || (self.instance.isTask === undefined && self.instance.showSolutions !== undefined)) {
+  const isChildInstanceTask = isTask(self.instance);
+
+  if (self.instance.showCPComments !== undefined || isChildInstanceTask) {
     // Mark slide as task in CP navigation bar
     self.instance.coursePresentationIndexOnSlide = self.parent.parent.elementInstances[self.parent.index].length - 1;
     if (self.parent.parent.slidesWithSolutions[self.parent.index] === undefined) {
@@ -77,11 +80,9 @@ function Element(parameters) {
     self.parent.parent.hasAnswerElements = true;
   }
 
-  if (!self.parent.parent.isTask && !self.parent.parent.hideSummarySlide) {
+  if (!self.parent.parent.isTask && !self.parent.parent.hideSummarySlide && isChildInstanceTask) {
     // CP is not a task by default, but it will be if one of the elements is task or have a solution
-    if (self.instance.isTask || (self.instance.isTask === undefined && self.instance.showSolutions !== undefined)) {
-      self.parent.parent.isTask = true; // (checking for showSolutions will not work for compound content types, which is why we added isTask instead.)
-    }
+    self.parent.parent.isTask = true; // (checking for showSolutions will not work for compound content types, which is why we added isTask instead.)
   }
 }
 

--- a/src/scripts/utils.js
+++ b/src/scripts/utils.js
@@ -106,3 +106,31 @@ const $STRIP_HTML_HELPER = $('<div>');
  * @return {string}
  */
 export const stripHTML = (str) => $STRIP_HTML_HELPER.html(str).text().trim();
+
+/**
+ * Checks whether a given instance is a task.
+ * @param {object} instance H5P.ContentType instance.
+ * @returns {boolean} True if the instance is a task, false otherwise.
+ */
+export const isTask = (instance) => {
+  if (typeof instance !== 'object' || instance === null) {
+    return false;
+  }
+
+  // Content type tells us right away whether it is a task - nice, but not documented and cannot be taken for granted
+  if (typeof instance.isTask === 'boolean') {
+    return instance.isTask;
+  }
+
+  // Check for showSolutions() as indicator for being a task
+  if (typeof instance.showSolutions === 'function') {
+    return true;
+  }
+
+  // Check for maxScore() > 0 as indicator for being a task
+  if (typeof instance.getMaxScore === 'function' && instance.getMaxScore() > 0) {
+    return true;
+  }
+
+  return false;
+};


### PR DESCRIPTION
When merged in, will amend the function that determines whether a child instance is a task, so more content types including SingleChoiceSet will be detected correctly.