### PR TITLE
fix / fix go to slide box title attribute encoding

### DIFF
--- a/src/scripts/go-to-slide.js
+++ b/src/scripts/go-to-slide.js
@@ -1,4 +1,4 @@
-import { addClickAndKeyboardListeners } from './utils';
+import { addClickAndKeyboardListeners, stripHTML } from './utils';
 import { jQuery as $, EventDispatcher } from './globals';
 
 /**
@@ -70,7 +70,7 @@ export default class GoToSlide {
       href: '#',
       'class': classes,
       tabindex: tabindex,
-      title: title
+      'aria-label': stripHTML(title),
     });
 
     addClickAndKeyboardListeners(this.$element, (event) => {
@@ -87,6 +87,10 @@ export default class GoToSlide {
    */
   attach($container) {
     $container.html('').addClass('h5p-go-to-slide').append(this.$element);
+
+    window.requestAnimationFrame(() => {
+      H5P.Tooltip(this.$element.get(0), { position: 'bottom' });
+    });
   }
 
   /**


### PR DESCRIPTION
Thank you for your interest in contributing to H5P! 🎉  
Please fill in the below sections to make your pull request:

**What kind of change does this PR introduce?**
Bug fix

**What is the current behaviour?**
The title attribute (browser tooltip) text shows HTML encoding. Cmp. https://github.com/h5p/moodle-mod_hvp/issues/470

**What is the new behaviour?**
The title attribute is replaced by an aria-label, the value is decoded, and the aria-label is used to fuel H5P.Tooltip as a replacement for the browser tooltip.

Closes https://github.com/h5p/moodle-mod_hvp/issues/470

## PR Checklist

Before submitting, please confirm:

- [x] I searched for existing issues/PRs first
- [x] I linked related issues/discussions
- [x] I tested my changes locally

Read the [contribution guidelines](https://github.com/h5p/.github/blob/master/CONTRIBUTING.md) to get your pr accepted more quickly.
